### PR TITLE
Hotfix: Wrong datatype in post-processing, wrong pass in tx adjust

### DIFF
--- a/experiments/tx_calibration.py
+++ b/experiments/tx_calibration.py
@@ -9,7 +9,7 @@ from console.spcm_control.acquisition_control import AcquistionControl
 from console.spcm_control.interface_acquisition_data import AcquisitionData
 from console.utilities.plot_unrolled_sequence import plot_unrolled_sequence
 import console.utilities.sequences as sequences
-from console.utilities.reconstruction.calibrate import tx_adjust
+from console.utilities.reconstruction.calibrate import flip_angle_fit
 
 # %%
 # Create acquisition control instance
@@ -43,7 +43,7 @@ acq_data: AcquisitionData = acq.run(parameter=params, sequence=seq)
 
 # %%
 # Average and take data of first coil (channeo 0)
-fa_fit, rx_peaks = tx_adjust(acq_data.raw, flip_angles=flip_angles)
+fa_fit, rx_peaks = flip_angle_fit(acq_data.raw, flip_angles=flip_angles)
 
 fig, ax = plt.subplots(1, 1, figsize=(10, 5))
 ax.plot(np.degrees(fa_fit[0, ...]), fa_fit[1, ...])

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -84,7 +84,7 @@ class AcquistionControl:
 
         # Attributes for data and dwell time of downsampled signal
         self._raw: np.ndarray = np.array([])
-        self._unproc: np.ndarray =np.array([])
+        self._unproc: np.ndarray = np.array([])
 
     def __del__(self):
         """Class destructor disconnecting measurement cards."""

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -83,8 +83,8 @@ class AcquistionControl:
         self.unrolled_sequence: UnrolledSequence | None = None
 
         # Attributes for data and dwell time of downsampled signal
-        self._raw: np.ndarray = np.ndarray([])
-        self._unproc: np.ndarray = np.ndarray([])
+        self._raw: np.ndarray = np.array([])
+        self._unproc: np.ndarray =np.array([])
 
     def __del__(self):
         """Class destructor disconnecting measurement cards."""
@@ -167,8 +167,8 @@ class AcquistionControl:
         # Define timeout for acquisition process: 5 sec + sequence duration
         timeout = 5 + sqnc.duration
 
-        self._raw = np.ndarray([])
-        self._unproc = np.ndarray([])
+        self._raw = np.array([])
+        self._unproc = np.array([])
 
         for k in range(parameter.num_averages):
             self.log.info("Acquisition %s/%s", k + 1, parameter.num_averages)
@@ -315,9 +315,7 @@ class AcquistionControl:
         unproc: np.ndarray = np.stack(unproc_channel_list, axis=1)
 
         # Assign processed data to private class attributes, stack average dimension
-        self._raw = raw[None, ...] if not self._raw.size > 0 else np.concatenate((self._raw, raw[None, ...]), axis=0)
+        self._raw = raw[None, ...] if self._raw.size == 0 else np.concatenate((self._raw, raw[None, ...]), axis=0)
         self._unproc = (
-            unproc[None, ...]
-            if not self._unproc.size > 0
-            else np.concatenate((self._unproc, unproc[None, ...]), axis=0)
+            unproc[None, ...] if self._unproc.size == 0 else np.concatenate((self._unproc, unproc[None, ...]), axis=0)
         )

--- a/src/console/utilities/reconstruction/calibrate.py
+++ b/src/console/utilities/reconstruction/calibrate.py
@@ -69,6 +69,6 @@ def flip_angle_fit(data: np.ndarray, flip_angles: np.ndarray) -> tuple[np.ndarra
     params = result[0]
 
     fa_fit = np.arange(flip_angles[0], flip_angles[-1] + 0.1, 0.1)
-    amp_fit = fa_model(fa_fit, **params)
+    amp_fit = fa_model(fa_fit, *params)
 
     return np.stack([fa_fit, amp_fit], axis=0), amplitudes


### PR DESCRIPTION
- empty array must be `np.array([])` not `np.ndarray([])`
- when passing an array by reference use `*array` instead of `**array` what requires a mapping 