### PR TITLE
Sequence calculation fix and setter function

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
 name: Pytest
 
 on:
-  push:
+  pull_request:
     branches:
       - '*'
 

--- a/.github/workflows/static-tests.yml
+++ b/.github/workflows/static-tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   linting:

--- a/examples/se_spectrum.py
+++ b/examples/se_spectrum.py
@@ -31,7 +31,8 @@ params = AcquisitionParameter(
 )
 
 # Run the acquisition
-acq_data: AcquisitionData = acq.run(parameter=params, sequence=seq)
+acq.set_sequence(parameter=params, sequence=seq)
+acq_data: AcquisitionData = acq.run()
 
 # Get decimated data from acquisition data object
 data = acq_data.raw.squeeze()

--- a/examples/t2_measurement.py
+++ b/examples/t2_measurement.py
@@ -33,7 +33,8 @@ params = AcquisitionParameter(
 )
 
 # Perform acquisition
-acq_data: AcquisitionData = acq.run(parameter=params, sequence=seq)
+acq.set_sequence(parameter=params, sequence=seq)
+acq_data: AcquisitionData = acq.run()
 data = np.mean(acq_data.raw, axis=0).squeeze()
 
 peaks = np.max(data, axis=-1)

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -97,7 +97,7 @@ class SequenceProvider(Sequence):
 
         self.larmor_freq: float = float("nan")
         self.sample_count: int = 0
-        self._seq: np.ndarray | None = None
+        self._sqnc_cache: list = []
 
     def dict(self) -> dict:
         """Abstract method which returns variables for logging in dictionary."""
@@ -469,6 +469,12 @@ class SequenceProvider(Sequence):
 
         As the 15th bit is not encoding the sign (as usual for int16), the values are casted to uint16 before shifting.
         """
+        if self._sqnc_cache:
+            # Reset unrolled sequence cache to free memory
+            print("Resetting sequence cache...")
+            del self._sqnc_cache
+            self._sqnc_cache = []
+
         try:
             # Check larmor frequency
             if larmor_freq > 10e6:
@@ -558,7 +564,7 @@ class SequenceProvider(Sequence):
         )
 
         # Save unrolled sequence in class
-        self._seq = np.concatenate(_seq)
+        self._sqnc_cache = _seq
 
         return UnrolledSequence(
             seq=_seq,
@@ -591,7 +597,7 @@ class SequenceProvider(Sequence):
         """
         fig, axis = plt.subplots(5, 1, figsize=(16, 9))
 
-        if self._seq is None:
+        if not self._sqnc_cache:
             print("No unrolled sequence...")
             return fig, axis
 
@@ -599,10 +605,11 @@ class SequenceProvider(Sequence):
         seq_end = int(time_range[1] * self.spcm_freq) if time_range[1] > time_range[0] else -1
         samples = np.arange(self.sample_count, dtype=float)[seq_start:seq_end] * self.spcm_dwell_time * 1e3
 
-        rf_signal = self._seq[0::4][seq_start:seq_end]
-        gx_signal = self._seq[1::4][seq_start:seq_end]
-        gy_signal = self._seq[2::4][seq_start:seq_end]
-        gz_signal = self._seq[3::4][seq_start:seq_end]
+        sqnc = np.concatenate(self._sqnc_cache)
+        rf_signal = sqnc[0::4][seq_start:seq_end]
+        gx_signal = sqnc[1::4][seq_start:seq_end]
+        gy_signal = sqnc[2::4][seq_start:seq_end]
+        gz_signal = sqnc[3::4][seq_start:seq_end]
 
         # Get digital signals
         adc_gate = gx_signal.astype(np.uint16) >> 15

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -189,7 +189,9 @@ class AcquisitionControl:
             # Check setup
             if not self.is_setup:
                 raise RuntimeError("Measurement cards are not setup.")
-        except RuntimeError as err:
+            if self.sqnc is None:
+                raise ValueError("No sequence set, call set_sequence() to set a sequence and acquisition parameter.")
+        except (RuntimeError, ValueError) as err:
             self.log.exception(err, exc_info=True)
             raise err
 

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -87,7 +87,7 @@ class AcquisitionControl:
         # Set sequence provider max. amplitude per channel according to values from tx_card
         self.seq_provider.max_amp_per_channel = self.tx_card.max_amplitude
 
-        self.unrolled_sequence: UnrolledSequence | None = None
+        self.sqnc: UnrolledSequence | None = None
 
         # Attributes for data and dwell time of downsampled signal
         self._raw: list[np.ndarray] = []
@@ -128,8 +128,8 @@ class AcquisitionControl:
         console.setFormatter(formatter)
         logging.getLogger("").addHandler(console)
 
-    def run(self, sequence: str | Sequence, parameter: AcquisitionParameter) -> AcquisitionData:
-        """Run an acquisition job.
+    def set_sequence(self, sequence: str | Sequence, parameter: AcquisitionParameter) -> None:
+        """Set sequence and acquisition parameter.
 
         Parameters
         ----------
@@ -140,15 +140,12 @@ class AcquisitionControl:
 
         Raises
         ------
-        RuntimeError
-            The measurement cards are not setup properly.
+        AttributeError
+            Invalid sequence provided.
         FileNotFoundError
             Invalid file ending of sequence file.
         """
         try:
-            # Check setup
-            if not self.is_setup:
-                raise RuntimeError("Measurement cards are not setup.")
             # Check sequence
             if isinstance(sequence, Sequence):
                 self.seq_provider.from_pypulseq(sequence)
@@ -159,46 +156,66 @@ class AcquisitionControl:
             else:
                 raise AttributeError("Invalid sequence, must be either string to .seq file or Sequence instance")
 
-        except (RuntimeError, FileNotFoundError, AttributeError) as err:
+        except (FileNotFoundError, AttributeError) as err:
             self.log.exception(err, exc_info=True)
             raise err
 
+        # Calculate sequence
+        self.sqnc = None
         self.log.info(
             "Unrolling sequence: %s",
             self.seq_provider.definitions["Name"].replace(" ", "_"),
         )
-        sqnc: UnrolledSequence = self.seq_provider.unroll_sequence(
+        self.sqnc = self.seq_provider.unroll_sequence(
             larmor_freq=parameter.larmor_frequency,
             b1_scaling=parameter.b1_scaling,
             fov_scaling=parameter.fov_scaling,
             grad_offset=parameter.gradient_offset,
         )
-        # Save unrolled sequence
-        self.unrolled_sequence = sqnc if sqnc else None
+        self.parameter = parameter
+
+
+    def run(self) -> AcquisitionData:
+        """Run an acquisition job.
+
+        Raises
+        ------
+        RuntimeError
+            The measurement cards are not setup properly
+        ValueError
+            Missing raw data or missing averages
+        """
+        try:
+            # Check setup
+            if not self.is_setup:
+                raise RuntimeError("Measurement cards are not setup.")
+        except RuntimeError as err:
+            self.log.exception(err, exc_info=True)
+            raise err
 
         # Define timeout for acquisition process: 5 sec + sequence duration
-        timeout = 5 + sqnc.duration
-        self.log.info("Sequence duration: %s s", sqnc.duration)
+        timeout = 5 + self.sqnc.duration
+        self.log.info("Sequence duration: %s s", self.sqnc.duration)
 
         self._unproc = []
         self._raw = []
 
-        for k in range(parameter.num_averages):
-            self.log.info("Acquisition %s/%s", k + 1, parameter.num_averages)
+        for k in range(self.parameter.num_averages):
+            self.log.info("Acquisition %s/%s", k + 1, self.parameter.num_averages)
 
             # Start masurement card operations
             self.rx_card.start_operation()
             time.sleep(0.5)
-            self.tx_card.start_operation(sqnc)
+            self.tx_card.start_operation(self.sqnc)
 
             # Get start time of acquisition
             time_start = time.time()
 
-            while len(self.rx_card.rx_data) < sqnc.adc_count:
+            while len(self.rx_card.rx_data) < self.sqnc.adc_count:
                 # Delay poll by 10 ms
                 time.sleep(0.01)
 
-                if len(self.rx_card.rx_data) >= sqnc.adc_count:
+                if len(self.rx_card.rx_data) >= self.sqnc.adc_count:
                     break
 
                 if time.time() - time_start > timeout:
@@ -206,30 +223,30 @@ class AcquisitionControl:
                     self.log.warning(
                         "Acquisition Timeout: Only received %s/%s adc events",
                         len(self.rx_card.rx_data),
-                        sqnc.adc_count,
+                        self.sqnc.adc_count,
                         stack_info=True,
                     )
                     break
 
             if len(self.rx_card.rx_data) > 0:
-                self.post_processing(parameter)
+                self.post_processing(self.parameter)
 
             self.tx_card.stop_operation()
             self.rx_card.stop_operation()
 
-            if parameter.averaging_delay > 0:
-                time.sleep(parameter.averaging_delay)
+            if self.parameter.averaging_delay > 0:
+                time.sleep(self.parameter.averaging_delay)
 
         try:
             # if not self._raw.size > 0:
             if not len(self._raw) > 0:
-                raise ValueError("Error during post processing or readout, no raw data")
+                raise ValueError("No raw data acquired...")
             # if len(self._raw) != parameter.num_averages:
-            if not all(gate.shape[0] == parameter.num_averages for gate in self._raw):
+            if not all(gate.shape[0] == self.parameter.num_averages for gate in self._raw):
                 raise ValueError(
-                    "Could not acquire all averages. Average dimensions: %s/%s",
+                    "Missing averages: %s/%s",
                     [gate.shape[0] for gate in self._raw],
-                    parameter.num_averages,
+                    self.parameter.num_averages,
                 )
         except ValueError as err:
             self.log.exception(err, exc_info=True)
@@ -245,8 +262,8 @@ class AcquisitionControl:
                 self.rx_card.__name__: self.rx_card.dict(),
                 self.seq_provider.__name__: self.seq_provider.dict()
             },
-            dwell_time=parameter.decimation / self.f_spcm,
-            acquisition_parameters=parameter,
+            dwell_time=self.parameter.decimation / self.f_spcm,
+            acquisition_parameters=self.parameter,
         )
 
     def post_processing(self, parameter: AcquisitionParameter) -> None:

--- a/src/console/utilities/sequences/system_settings.py
+++ b/src/console/utilities/sequences/system_settings.py
@@ -1,8 +1,6 @@
 """Global definition of system settings to be imported by sequence constructors."""
-from pypulseq.opts import Opts
-import numpy as np
-from decimal import Decimal
 
+from pypulseq.opts import Opts
 
 system = Opts(
     # time delay at the end of RF event, SETS RF DELAY!

--- a/src/console/utilities/sequences/system_settings.py
+++ b/src/console/utilities/sequences/system_settings.py
@@ -9,10 +9,10 @@ system = Opts(
     rf_dead_time=20e-6,
 
     # Set raster times to spectrum card frequency (timing checks)
-    grad_raster_time=1e-5,
-    rf_raster_time=1e-5,
-    block_duration_raster=1e-5,
-    adc_raster_time=1e-5,
+    grad_raster_time=1e-6,
+    rf_raster_time=1e-6,
+    block_duration_raster=1e-6,
+    adc_raster_time=1e-6,
 
     # Time delay at the beginning of an RF event
     # rf_ringdown_time=100e-6,

--- a/src/console/utilities/sequences/system_settings.py
+++ b/src/console/utilities/sequences/system_settings.py
@@ -1,15 +1,18 @@
 """Global definition of system settings to be imported by sequence constructors."""
 from pypulseq.opts import Opts
+import numpy as np
+from decimal import Decimal
+
 
 system = Opts(
     # time delay at the end of RF event, SETS RF DELAY!
     rf_dead_time=20e-6,
 
     # Set raster times to spectrum card frequency (timing checks)
-    grad_raster_time=1e-6,
-    rf_raster_time=1e-6,
-    block_duration_raster=1e-6,
-    adc_raster_time=1e-6,
+    grad_raster_time=1e-5,
+    rf_raster_time=1e-5,
+    block_duration_raster=1e-5,
+    adc_raster_time=1e-5,
 
     # Time delay at the beginning of an RF event
     # rf_ringdown_time=100e-6,
@@ -20,3 +23,25 @@ system = Opts(
     max_slew=5000,
     slew_unit="T/m/s",
 )
+
+
+# Helper function
+def raster(val: float, precision: float) -> float:
+    """Fit value to gradient raster.
+
+    Parameters
+    ----------
+    val
+        Time value to be aligned on the raster.
+    precision
+        Raster precision, e.g. system.grad_raster_time or system.adc_raster_time
+
+    Returns
+    -------
+        Value wih given time/raster precision
+    """
+    # return np.round(val / precision) * precision
+    gridded_val = round(val / precision) * precision
+    return gridded_val
+    # decimals = abs(Decimal(str(precision)).as_tuple().exponent)
+    # return round(gridded_val, ndigits=decimals)

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -6,7 +6,7 @@ import numpy as np
 import pypulseq as pp
 
 from console.spcm_control.interface_acquisition_parameter import Dimensions
-from console.utilities.sequences.system_settings import system, raster
+from console.utilities.sequences.system_settings import raster, system
 
 default_fov = Dimensions(x=220e-3, y=220e-3, z=225e-3)
 default_encoding = Dimensions(x=70, y=70, z=49)

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -42,7 +42,8 @@ def constructor(
     fov, optional
         Field of view per dimension, by default default_fov
     n_enc, optional
-        Number of encoding steps per dimension, by default default_encoding
+        Number of encoding steps per dimension, by default default_encoding = Dimensions(x=70, y=70, z=49).
+        If an encoding dimension is set to 1, the TSE sequence becomes a 2D sequence.
 
     Returns
     -------
@@ -97,8 +98,8 @@ def constructor(
     pe0 = np.arange(n_enc.y) - int((n_enc.y - 1) / 2)
     pe1 = np.arange(n_enc.z) - int((n_enc.z - 1) / 2)
 
-    pe0_ordered = pe0[np.argsort(np.abs(pe0 - 0.5))]
-    pe1_ordered = pe1[np.argsort(np.abs(pe1 - 0.5))]
+    pe0_ordered = pe0[np.argsort(np.abs(pe0 - 0.1))]
+    pe1_ordered = pe1[np.argsort(np.abs(pe1 - 0.1))]
 
     pe_traj = np.stack([grid.flatten() for grid in np.meshgrid(pe0_ordered, pe1_ordered, indexing='ij')], axis=-1)
 
@@ -140,9 +141,9 @@ def constructor(
 
             ro_counter += 1
 
-            # Add TR after echo train, if not the last readout
-            if ro_counter < n_enc.y * n_enc.z:
-                seq.add_block(pp.make_delay(raster(val=tr_delay, precision=system.block_duration_raster)))
+        # Add TR after echo train, if not the last readout
+        if ro_counter < n_enc.y * n_enc.z:
+            seq.add_block(pp.make_delay(raster(val=tr_delay, precision=system.block_duration_raster)))
 
     # Calculate some sequence measures
     train_duration_tr = (seq.duration()[0] + tr_delay) / len(trains)

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -77,7 +77,7 @@ def constructor(
 
     adc = pp.make_adc(
         system=system,
-        num_samples=int(adc_duration/system.adc_raster_time),
+        num_samples=int((adc_duration + adc_correction)/system.adc_raster_time),
         duration=raster(val=adc_duration + adc_correction, precision=system.adc_raster_time),
         delay=raster(val=gradient_correction + grad_ro.rise_time, precision=system.adc_raster_time)
     )

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -6,7 +6,7 @@ import numpy as np
 import pypulseq as pp
 
 from console.spcm_control.interface_acquisition_parameter import Dimensions
-from console.utilities.sequences.system_settings import system
+from console.utilities.sequences.system_settings import system, raster
 
 default_fov = Dimensions(x=220e-3, y=220e-3, z=225e-3)
 default_encoding = Dimensions(x=70, y=70, z=49)
@@ -17,7 +17,8 @@ def constructor(
     repetition_time: float = 600e-3,
     etl: int = 7,
     rf_duration: float = 400e-6,
-    gradient_correction: float = 510e-6,
+    gradient_correction: float = 0.,
+    adc_correction: float = 0.,
     ro_bandwidth: float = 20e3,
     fov: Dimensions = default_fov,
     n_enc: Dimensions = default_encoding,
@@ -77,14 +78,9 @@ def constructor(
     adc = pp.make_adc(
         system=system,
         num_samples=int(adc_duration/system.adc_raster_time),
-        duration=adc_duration,
-        delay=gradient_correction + grad_ro.rise_time,
+        duration=raster(val=adc_duration + adc_correction, precision=system.adc_raster_time),
+        delay=raster(val=gradient_correction + grad_ro.rise_time, precision=system.adc_raster_time)
     )
-
-    def grad_raster(val: float) -> float:
-        """Fit value to gradient raster."""
-        # return round(val / system.grad_raster_time) * system.grad_raster_time
-        return np.ceil(val / system.grad_raster_time) * system.grad_raster_time
 
     # Calculate delays
     # Note: RF dead-time is contained in RF delay
@@ -118,7 +114,7 @@ def constructor(
 
         seq.add_block(rf_90)
         seq.add_block(grad_ro_pre)
-        seq.add_block(pp.make_delay(grad_raster(tau_1)))
+        seq.add_block(pp.make_delay(raster(val=tau_1, precision=system.grad_raster_time)))
 
         for echo in train:
 
@@ -131,11 +127,11 @@ def constructor(
                 pp.make_trapezoid(channel="z", area=-pe_1, duration=ro_pre_duration, system=system)
             )
 
-            seq.add_block(pp.make_delay(grad_raster(tau_2)))
+            seq.add_block(pp.make_delay(raster(val=tau_2, precision=system.grad_raster_time)))
 
             seq.add_block(grad_ro, adc)
 
-            seq.add_block(pp.make_delay(grad_raster(tau_3)))
+            seq.add_block(pp.make_delay(raster(val=tau_3, precision=system.grad_raster_time)))
 
             seq.add_block(
                 pp.make_trapezoid(channel="y", area=pe_0, duration=ro_pre_duration, system=system),
@@ -146,7 +142,7 @@ def constructor(
 
             # Add TR after echo train, if not the last readout
             if ro_counter < n_enc.y * n_enc.z:
-                seq.add_block(pp.make_delay(round(tr_delay / 1e-6) * 1e-6))
+                seq.add_block(pp.make_delay(raster(val=tr_delay, precision=system.block_duration_raster)))
 
     # Calculate some sequence measures
     train_duration_tr = (seq.duration()[0] + tr_delay) / len(trains)
@@ -159,3 +155,5 @@ def constructor(
     seq.set_definition("tr_delay", tr_delay)
 
     return (seq, trains)
+
+# %%


### PR DESCRIPTION
This pull request contains the following updates:

- [x] Fixed index of gradient `max_output` in sequence gradient calculation
- [x] Function to calculate sequence durations on a given raster time
- [x] Updated 3D TSE sequence
- [x] Implementation of a setter function for sequence and parameter in acquisition control

_Setter Function Notes_ 
So far, the sequence and the acquisition parameter were passed to the `run()` call of the acquisition control.
This requires the calculation/unrolling of the sequence on every call to `run()`, even if the sequence and the parameter remain unchanged. With the setter function, the sequence is calculated on every call to the setter. Thereby, the same sequence can be executed multiple times without calculating it again if the parameters are not changed.
 